### PR TITLE
Adds support for IAU codes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `proj:epsg` is not required in Item properties anymore. `proj:epsg` is recommended now, but not required in any scope.
 - Updated the PROJJSON schema to v0.5
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.1.0] - 2023-02-10
 
 ### Added
-
-- Added examples for Collections and Assets (in Items)
-
-### Changed
+- Definition for authority and code instead of a hard coded EPSG. The EPSG code field was maintained for backwards compatibility.
 
 - `proj:epsg` is not required in Item properties anymore. `proj:epsg` is recommended now, but not required in any scope.
 - Updated the PROJJSON schema to v0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The new field `proj:code` was introduced as a more general way to describe projection codes for various authorities, not just EPSG. 
-`proj:espg` was removed and can be migrated to `proj:code`. A former `"proj:epsg": 3857` is now `"proj:code": "EPSG:3857" 
+`proj:espg` was removed and can be migrated to `proj:code`. A former `"proj:epsg": 3857` is now `"proj:code": "EPSG:3857"`
 
 ## [v1.1.0] - 2023-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [v1.1.0] - 2023-02-08
+### Changed
+- Definition for authority and code instead of a hard coded EPSG. The EPSG code field was maintained for backwards compatibility.
+## [v1.1.0] - 2023-02-10
 
 ### Added
 
 - Added examples for Collections and Assets (in Items)
 
 ### Changed
-
 - `proj:epsg` is not required in Item properties anymore. `proj:epsg` is recommended now, but not required in any scope.
 - Updated the PROJJSON schema to v0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v1.1.0] - 2023-02-10
+## [v1.1.0] - 2023-02-08
 
 ### Added
 
@@ -16,10 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `proj:epsg` is not required in Item properties anymore. `proj:epsg` is recommended now, but not required in any scope.
 - Updated the PROJJSON schema to v0.5
-
-### Deprecated
-
-### Removed
 
 ### Fixed
 
@@ -32,6 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial independent release, see [previous history](https://github.com/radiantearth/stac-spec/commits/v1.0.0-rc.2/extensions/projection)
 
-[Unreleased]: <https://github.com/stac-extensions/projection/compare/v1.1.0...HEAD>
+[Unreleased]: <https://github.com/stac-extensions/projection/compare/v1.0.0...HEAD>
 [v1.1.0]: <https://github.com/stac-extensions/projection/compare/v1.0.0...v1.1.0>
 [v1.0.0]: <https://github.com/stac-extensions/projection/tree/v1.0.0>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- The new field `proj:code` was introduced as a more general way to describe projection codes for various authorities, not just EPSG. `proj:espg` was removed and can be migrated to `proj:code`. A former `"proj:epsg": 3857` is now `"proj:code": "EPSG:3857" 
+- The new field `proj:code` was introduced as a more general way to describe projection codes for various authorities, not just EPSG. 
+`proj:espg` was removed and can be migrated to `proj:code`. A former `"proj:epsg": 3857` is now `"proj:code": "EPSG:3857" 
 
 ## [v1.1.0] - 2023-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Definition for authority and code instead of a hard coded EPSG. The EPSG code field was maintained for backwards compatibility.
+- The new field `proj:code` was introduced as a more general way to describe projection codes for various authorities, not just EPSG. `proj:espg` was removed and can be migrated to `proj:code`. A former `"proj:epsg": 3857` is now `"proj:code": "EPSG:3857" 
 
 ## [v1.1.0] - 2023-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Definition for authority and code instead of a hard coded EPSG. The EPSG code field was maintained for backwards compatibility.
 
-- `proj:epsg` is not required in Item properties anymore. `proj:epsg` is recommended now, but not required in any scope.
 - Updated the PROJJSON schema to v0.5
+
+### Deprecated
+
+### Removed
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.1.0] - 2023-02-10
 
 ### Added
-- Definition for authority and code instead of a hard coded EPSG. The EPSG code field was maintained for backwards compatibility.
+
+- Added examples for Collections and Assets (in Items)
+
+### Changed
 
 - Updated the PROJJSON schema to v0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- The new field `proj:code` was introduced as a more general way to describe projection codes for various authorities, not just EPSG. 
-`proj:espg` was removed and can be migrated to `proj:code`. A former `"proj:epsg": 3857` is now `"proj:code": "EPSG:3857"`
+### Added
+
+- The new field `proj:code` was introduced as a more general way to describe projection codes for various authorities, not just EPSG.
+
+### Deprecated
+
+- `proj:espg` was deprecated in favor of `proj:code`.
+  A former `"proj:epsg": 3857` is now `"proj:code": "EPSG:3857"`.
 
 ## [v1.1.0] - 2023-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Definition for authority and code instead of a hard coded EPSG. The EPSG code field was maintained for backwards compatibility.
+
 ## [v1.1.0] - 2023-02-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Changed
 - Definition for authority and code instead of a hard coded EPSG. The EPSG code field was maintained for backwards compatibility.
 
@@ -29,6 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial independent release, see [previous history](https://github.com/radiantearth/stac-spec/commits/v1.0.0-rc.2/extensions/projection)
 
-[Unreleased]: <https://github.com/stac-extensions/projection/compare/v1.0.0...HEAD>
+[Unreleased]: <https://github.com/stac-extensions/projection/compare/v1.1.0...HEAD>
 [v1.1.0]: <https://github.com/stac-extensions/projection/compare/v1.0.0...v1.1.0>
 [v1.0.0]: <https://github.com/stac-extensions/projection/tree/v1.0.0>

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ A Coordinate Reference System (CRS) is the data reference system (sometimes call
 [EPSG code](https://en.wikipedia.org/wiki/EPSG_Geodetic_Parameter_Dataset).
 A great tool to help find EPSG codes is [epsg.io](http://epsg.io/).
 
-This field must be set to `null` in the following cases:
+This field SHOULD be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid EPSG code for it. In this case, the CRS should be provided in `proj:wkt2` and/or `proj:projjson`.
   Clients can prefer to take either, although there may be discrepancies in how each might be interpreted.
@@ -82,7 +82,7 @@ This field must be set to `null` in the following cases:
 A Coordinate Reference System (CRS) is the data reference system (sometimes called a 'projection')
 used by the asset data. This value is a [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string.
 
-This field should be set to `null` in the following cases:
+This field SHOULD be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid WKT2 string for it.
 
@@ -92,7 +92,7 @@ A Coordinate Reference System (CRS) is the data reference system (sometimes call
 used by the asset data. This value is a [PROJJSON](https://proj.org/specifications/projjson.html) object, 
 see the [JSON Schema](https://proj.org/schemas/v0.5/projjson.schema.json) for details.
 
-This field should be set to `null` in the following cases:
+This field SHOULD be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid WKT2 string for it.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ clients are likely to support are listed in the following table.
 | European Petroleum Survey Groups (EPSG) | <http://www.opengis.net/def/crs/EPSG> or <http://epsg.org> |
 | International Astronomical Union (IAU)  | <http://www.opengis.net/def/crs/IAU/2015>                  |
 | Open Geospatial Consortium (OGC)        | <http://www.opengis.net/def/crs/OGC>                       |
-| ESRI                                    | <https://spatialreference.org/ref/esri/ >                  |
+| ESRI                                    | <https://spatialreference.org/ref/esri/>                  |
 
 The `proj:code` field SHOULD be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ The fields in the table below can be used in these parts of STAC documents:
 
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
-| proj:epsg        | integer\|null   | [EPSG code](http://www.opengis.net/def/crs/EPSG) of the datasource; Maintained for backwards compatability and will be deprecated in V2.0.0. Please use `proj:authority` and `proj:code`. |
-| proj:code        | string\|null   | Authority specific code of the data source (e.g., [EPSG](http://www.opengis.net/def/crs/EPSG), [IAU](http://www.opengis.net/def/crs/IAU/2015)) |
+| proj:epsg        | integer\|null   | [EPSG code](https://epsg.org/) of the datasource; Maintained for backwards compatability and will be deprecated in V2.0.0. Please use `proj:authority` and `proj:code`. |
+| proj:code        | string\|null   | Authority specific code of the data source (e.g., [EPSG](https://epsg.org/), [IAU](http://www.opengis.net/def/crs/IAU/2015)) |
 | proj:authority   | string\|null    | The name of the authority that designated the `proj:code` of the datasource. Known authorities are identified [below](#projauthority).|
 | proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |

--- a/README.md
+++ b/README.md
@@ -85,12 +85,20 @@ would be represented as:
 
 Projection codes are identified by a string. The [proj](https://proj.org/) library defines projections 
 using "authority:code", e.g., "EPSG:4326" or "IAU_2015:30100". Different projection authorities may define 
-different string formats.
+different string formats. Examples of known projection authorities, where when can find well known codes that 
+clients are likely to support are listed in the following table.
+
+| Authority Name | URL |
+| -------------- |  --- |
+| European Petroleum Survey Groups (EPSG) |  http://www.opengis.net/def/crs/EPSG or http://epsg.org |
+| International Astronomical Union (IAU) | http://www.opengis.net/def/crs/IAU/2015 |
+| Open Geospatial Consortium (OGC) |  http://www.opengis.net/def/crs/OGC |
 
 The `proj:code` field SHOULD be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid EPSG code for it. In this case, the CRS should be provided in `proj:wkt2` and/or `proj:projjson`.
   Clients can prefer to take either, although there may be discrepancies in how each might be interpreted.
+
 
 #### proj:wkt2
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ clients are likely to support are listed in the following table.
 | Authority Name                          | URL                                                        |
 | --------------------------------------- | ---------------------------------------------------------- |
 | European Petroleum Survey Groups (EPSG) | <http://www.opengis.net/def/crs/EPSG> or <http://epsg.org> |
-| International Astronomical Union (IAU)  | <http://www.opengis.net/def/crs/IAU/2015>                  |
-| Open Geospatial Consortium (OGC)        | <http://www.opengis.net/def/crs/OGC>                       |
+| International Astronomical Union (IAU)  | <http://www.opengis.net/def/crs/IAU>                      |
+| Open Geospatial Consortium (OGC)        | <http://www.opengis.net/def/crs/OGC>                      |
 | ESRI                                    | <https://spatialreference.org/ref/esri/>                  |
 
 The `proj:code` field SHOULD be set to `null` in the following cases:

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ The fields in the table below can be used in these parts of STAC documents:
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
 | proj:epsg        | integer\|null   | [EPSG code](http://www.epsg-registry.org/) of the datasource; Maintained for backwards compatability and will be deprecated in V2.0.0. Please use `proj:authority` and `proj:code`. |
-| proj:code        | string\|null   | Authority specific code of the data source (e.g., [EPSG](http://www.epsg-registry.org/), [IAU](http://voparis-vespa-crs.obspm.fr:8080/web/2015.html)) |
-| proj:authority   | string\|null    | The name of the authority that designated the `proj:code` of the datasource. |
+| proj:code        | string\|null   | Authority specific code of the data source (e.g., [EPSG](http://www.epsg-registry.org/), [IAU](http://www.opengis.net/def/crs/IAU/2015)) |
+| proj:authority   | string\|null    | The name of the authority that designated the `proj:code` of the datasource. Known authorities are identified by the [OGC](http://www.opengis.net/def/crs/) and include: `OGC`, `EPSG`, `IAU`, and `COSMO`.|
 | proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:geometry    | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | Defines the footprint of this Item. |

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ clients are likely to support are listed in the following table.
 | European Petroleum Survey Groups (EPSG) | <http://www.opengis.net/def/crs/EPSG> or <http://epsg.org> |
 | International Astronomical Union (IAU)  | <http://www.opengis.net/def/crs/IAU/2015>                  |
 | Open Geospatial Consortium (OGC)        | <http://www.opengis.net/def/crs/OGC>                       |
+| ESRI                                    | <https://spatialreference.org/ref/esri/ >                  |
 
 The `proj:code` field SHOULD be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ as they are specific to assets and may not apply to all assets.
 For example, if you provide a smaller and unlocated thumbnail, having the projection information in the Item Properties
 would imply that the projection information also applies to the thumbnail if not specified otherwise in the asset.
 You may want to add the `proj:srid`` to the Item Properties though as this would provide an easy way to
-filter for specific projection codes in an API.
-In this case you could override the `proj:srid` for the thumbnail on the asset level.
+filter for specific projection codes in an API. In this case you could override the `proj:srid` for the thumbnail on the asset level.
 
 ### Additional Field Information
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The fields in the table below can be used in these parts of STAC documents:
 
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
-| proj:srid        | string\|null   | Authority and specific code of the data source (e.g., ["EPSG:####"](https://epsg.org/), ["IAU:#####"](http://www.opengis.net/def/crs/IAU/2015)) |
+| proj:code        | string\|null   | Authority and specific code of the data source (e.g., ["EPSG:####"](https://epsg.org/), ["IAU:#####"](http://www.opengis.net/def/crs/IAU/2015)) |
 | proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:geometry    | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | Defines the footprint of this Item. |
@@ -53,17 +53,17 @@ Generally, it is preferrable to provide the projection information on the Asset 
 as they are specific to assets and may not apply to all assets.
 For example, if you provide a smaller and unlocated thumbnail, having the projection information in the Item Properties
 would imply that the projection information also applies to the thumbnail if not specified otherwise in the asset.
-You may want to add the `proj:srid`` to the Item Properties though as this would provide an easy way to
-filter for specific projection codes in an API. In this case you could override the `proj:srid` for the thumbnail on the asset level.
+You may want to add the `proj:code` to the Item Properties though as this would provide an easy way to
+filter for specific projection codes in an API. In this case you could override the `proj:code` for the thumbnail on the asset level.
 
 ### Additional Field Information
 
 #### proj:epsg
 
-**Notice**: This field has been removed in V2.0.0. See [proj:epsg Migration to V2](#projepsg-migration-to-projsrid).
+**Notice**: This field has been removed in V2.0.0. See [proj:epsg Migration to V2](#projepsg-migration-to-projcode).
 
-#### proj:epsg Migration to proj:srid
-`proj:epsg` is removed in version 2.0.0 of this extension. Please use `proj:srid`. For example, the following:
+#### proj:epsg Migration to proj:code
+`proj:epsg` is removed in version 2.0.0 of this extension. Please use `proj:code`. For example, the following:
 
 ```json
 {
@@ -76,18 +76,18 @@ would be represented as:
 ```json
 {
   ...
-  "proj:srid": "EPSG:32659",
+  "proj:code": "EPSG:32659",
   ...
 }
 ```
 
-#### proj:srid
+#### proj:code
 
 Projection codes are identified by a string. The [proj](https://proj.org/) library defines projections 
 using "authority:code", e.g., "EPSG:4326" or "IAU_2015:30100". Different projection authorities may define 
 different string formats.
 
-The `proj:srid` field SHOULD be set to `null` in the following cases:
+The `proj:code` field SHOULD be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid EPSG code for it. In this case, the CRS should be provided in `proj:wkt2` and/or `proj:projjson`.
   Clients can prefer to take either, although there may be discrepancies in how each might be interpreted.
@@ -115,14 +115,14 @@ This field SHOULD be set to `null` in the following cases:
 
 A GeoJSON Geometry object as defined in [RFC 7946, sections 3.1](https://tools.ietf.org/html/rfc7946)
 representing the footprint of this Item, except not necessarily in EPSG:4326 as required by RFC7946.
-Specified based on the `proj:srid`, `proj:projjson` or `proj:wkt2` fields (not necessarily EPSG:4326).
+Specified based on the `proj:code`, `proj:projjson` or `proj:wkt2` fields (not necessarily EPSG:4326).
 Usually, this will be represented by a Polygon with five coordinates, as the item in the asset data CRS should be
 a square aligned to the original CRS grid.
 
 #### proj:bbox
 
 Bounding box of the assets represented by this Item in the asset data CRS. Specified as 4 or 6
-coordinates based on the CRS defined in the `proj:srid`, `proj:projjson` or `proj:wkt2` fields.  First two numbers are coordinates
+coordinates based on the CRS defined in the `proj:code`, `proj:projjson` or `proj:wkt2` fields.  First two numbers are coordinates
 of the lower left corner, followed by coordinates of upper right corner, , e.g., \[west, south, east, north],
 \[xmin, ymin, xmax, ymax], \[left, down, right, up], or \[west, south, lowest, east, north, highest]. 
 The length of the array must be 2\*n where n is the number of dimensions. The array contains all axes of the southwesterly
@@ -187,7 +187,7 @@ This object represents the centroid of the Item Geometry.
 There are several projection extension fields with potentially overlapping functionality. This section attempts to 
 give an overview of which ones you should consider using. They fit into three general categories:
 
-- **Description of the coordinate reference system:** [proj:srid](#projsrid) is recommended, but it is just a 
+- **Description of the coordinate reference system:** [proj:code](#projcode) is recommended, but it is just a 
 reference to known projection information. [WKT2](#projwkt2) and [PROJJSON](#projprojjson) are two options to 
 fully describe the projection information. 
 
@@ -233,7 +233,7 @@ is likely ok if you aren't worried about legacy client support.
 
 ### Thumbnails
 
-For (unlocated) thumbnails and similar imagery, it is recommended set `proj:srid` to `null` and include `proj:shape`
+For (unlocated) thumbnails and similar imagery, it is recommended set `proj:code` to `null` and include `proj:shape`
 so that
 1. clients can read the image dimensions upfront (and reserve space for them), and
 2. you explicitly state that the thumbnail is not geolocated.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The fields in the table below can be used in these parts of STAC documents:
 
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
-| proj:code        | string\|null   | Authority and specific code of the data source (e.g., ["EPSG:####"](https://epsg.org/), ["IAU:#####"](http://www.opengis.net/def/crs/IAU/2015)) |
+| proj:srid        | string\|null   | Authority and specific code of the data source (e.g., ["EPSG:####"](https://epsg.org/), ["IAU:#####"](http://www.opengis.net/def/crs/IAU/2015)) |
 | proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:geometry    | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | Defines the footprint of this Item. |
@@ -48,15 +48,14 @@ The fields in the table below can be used in these parts of STAC documents:
 
 At least one of the fields MUST be specified, but it is RECOMMENDED to provide more information as detailed in the
 [Best Practices section](#best-practices) so that, for example, GDAL can read your data without issues. 
-If specifying `proj:code` or `proj:authority`, both fields MUST be specified.
 
 Generally, it is preferrable to provide the projection information on the Asset level
 as they are specific to assets and may not apply to all assets.
 For example, if you provide a smaller and unlocated thumbnail, having the projection information in the Item Properties
 would imply that the projection information also applies to the thumbnail if not specified otherwise in the asset.
-You may want to add the `proj:code`` to the Item Properties though as this would provide an easy way to
+You may want to add the `proj:srid`` to the Item Properties though as this would provide an easy way to
 filter for specific projection codes in an API.
-In this case you could override the `proj:code` for the thumbnail on the asset level.
+In this case you could override the `proj:srid` for the thumbnail on the asset level.
 
 ### Additional Field Information
 
@@ -64,8 +63,8 @@ In this case you could override the `proj:code` for the thumbnail on the asset l
 
 **Notice**: This field has been removed in V2.0.0. See [proj:epsg Migration to V2](#projepsg-migration-to-v2).
 
-#### proj:epsg Migration to proj:code
-`proj:epsg` is removed in version 2.0.0 of this extension. Please use `proj:code`. For example, the following:
+#### proj:epsg Migration to proj:srid
+`proj:epsg` is removed in version 2.0.0 of this extension. Please use `proj:srid`. For example, the following:
 
 ```json
 {
@@ -78,16 +77,16 @@ would be represented as:
 ```json
 {
   ...
-  "proj:code": "EPSG:32659",
+  "proj:srid": "EPSG:32659",
   ...
 }
 ```
 
-#### proj:code
+#### proj:srid
 
 Projection codes are identified by a string. The [proj](https://proj.org/) library defines projections using "authority:code", e.g., "EPSG:4326" or "IAU_2015:30100". Different projection authorities may define different string formats.
 
-The `proj:code` field SHOULD be set to `null` in the following cases:
+The `proj:srid` field SHOULD be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid EPSG code for it. In this case, the CRS should be provided in `proj:wkt2` and/or `proj:projjson`.
   Clients can prefer to take either, although there may be discrepancies in how each might be interpreted.
@@ -115,14 +114,14 @@ This field SHOULD be set to `null` in the following cases:
 
 A GeoJSON Geometry object as defined in [RFC 7946, sections 3.1](https://tools.ietf.org/html/rfc7946)
 representing the footprint of this Item, except not necessarily in EPSG:4326 as required by RFC7946.
-Specified based on the `proj:code`, `proj:projjson` or `proj:wkt2` fields (not necessarily EPSG:4326).
+Specified based on the `proj:srid`, `proj:projjson` or `proj:wkt2` fields (not necessarily EPSG:4326).
 Usually, this will be represented by a Polygon with five coordinates, as the item in the asset data CRS should be
 a square aligned to the original CRS grid.
 
 #### proj:bbox
 
 Bounding box of the assets represented by this Item in the asset data CRS. Specified as 4 or 6
-coordinates based on the CRS defined in the `proj:code`, `proj:projjson` or `proj:wkt2` fields.  First two numbers are coordinates
+coordinates based on the CRS defined in the `proj:srid`, `proj:projjson` or `proj:wkt2` fields.  First two numbers are coordinates
 of the lower left corner, followed by coordinates of upper right corner, , e.g., \[west, south, east, north],
 \[xmin, ymin, xmax, ymax], \[left, down, right, up], or \[west, south, lowest, east, north, highest]. 
 The length of the array must be 2\*n where n is the number of dimensions. The array contains all axes of the southwesterly
@@ -187,7 +186,7 @@ This object represents the centroid of the Item Geometry.
 There are several projection extension fields with potentially overlapping functionality. This section attempts to 
 give an overview of which ones you should consider using. They fit into three general categories:
 
-- **Description of the coordinate reference system:** [proj:code](#proj:code) is recommended, but it is just a reference to known projection information. [WKT2](#projwkt2) and [PROJJSON](#projprojjson) are two options to fully describe the projection information. 
+- **Description of the coordinate reference system:** [proj:srid](#proj:srid) is recommended, but it is just a reference to known projection information. [WKT2](#projwkt2) and [PROJJSON](#projprojjson) are two options to fully describe the projection information. 
 This is typically done for projections that aren't available or fully described in a known registry (e.g., [EPSG Registry](https://epsg.org/) or [IAU Registry](http://www.opengis.net/def/crs/IAU/2015)). 
 For example, the MODIS Sinusoidal projection does not have an EPSG code, but can be described using WKT2 or PROJJSON.
 - **Description of the native geometry information:** STAC requires the geometry and bounding box, but they are only available
@@ -224,7 +223,7 @@ is likely ok if you aren't worried about legacy client support.
 
 ### Thumbnails
 
-For (unlocated) thumbnails and similar imagery, it is recommended set `proj:code` to `null` and include `proj:shape`
+For (unlocated) thumbnails and similar imagery, it is recommended set `proj:srid` to `null` and include `proj:shape`
 so that
 1. clients can read the image dimensions upfront (and reserve space for them), and
 2. you explicitly state that the thumbnail is not geolocated.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The fields in the table below can be used in these parts of STAC documents:
 
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
-| proj:epsg        | string   | [EPSG code](http://www.epsg-registry.org/) of the datasource; Maintained for backwards compatability. Please use `proj:authority` and `proj:code`. |
+| proj:epsg        | integer   | [EPSG code](http://www.epsg-registry.org/) of the datasource; Maintained for backwards compatability and will be deprecated in V2.0.0. Please use `proj:authority` and `proj:code`. |
 | proj:code        | string   | [EPSG code](http://www.epsg-registry.org/) or other code (e.g., [IAU](http://voparis-vespa-crs.obspm.fr:8080/web/2015.html)) of the datasource |
 | proj:authority   | string    | The name of the authority that designated the proj:code of the datasource. |
 | proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
@@ -49,7 +49,8 @@ The fields in the table below can be used in these parts of STAC documents:
 | proj:transform   | \[number]       | The affine transformation coefficients for the default grid  |
 
 At least one of the fields MUST be specified, but it is RECOMMENDED to provide more information as detailed in the
-[Best Practices section](#best-practices) so that, for example, GDAL can read your data without issues.
+[Best Practices section](#best-practices) so that, for example, GDAL can read your data without issues. 
+If specifying `proj:code` or `proj:authority`, both fields MUST be specified.
 
 Also, [version 1.0.0](https://github.com/stac-extensions/projection/releases/tag/v1.0.0) of this extension
 required `proj:epsg` (either as integer or null) in Item Properties.
@@ -62,6 +63,10 @@ would imply that the projection information also applies to the thumbnail if not
 You may want to add the EPSG code to the Item Properties though as this would provide an easy way to
 filter for specific EPSG codes in an API.
 In this case you could override the EPSG code for the thumbnail on the asset level.
+
+The projection authority is some domain governing body that defines commonly used projections. 
+The contents of this field are permissive and any string can be provided. In practice, it is preferable to use a known authority. 
+Examples include: `epsg`, `iau_2015`, or `ogc`.
 
 ### Additional Field Information
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This document explains the Projection Extension to the
 When specified in Item Properties, the values are assumed to apply to all Assets in that Item. For example, an Item may have
 several related Assets each representing a band or layer for the Item, and which typically all use the same CRS,
 e.g., a UTM Zone. However, there may also be Assets intended for display, like a preview image or thumbnail, that have
-been reprojected to a different CRS, e.g., Web Mercator, or resized to better accommodate that use case. In this case, the 
+been reprojected to a different CRS, e.g., Web Mercator, or resized to better accommodate that use case. In this case, the
 fields should be specified at the Item Asset level, while those Item Asset objects that use the defaults can remain unspecified.
 
 The `proj` prefix is short for "projection", and is not a reference to the PROJ/PROJ4 formats.
@@ -35,19 +35,20 @@ The fields in the table below can be used in these parts of STAC documents:
 - [x] Assets (for both Collections and Items, incl. Item Asset Definitions in Collections)
 - [ ] Links
 
-| Field Name       | Type                     | Description |
-| ---------------- | ------------------------ | ----------- |
-| proj:code        | string\|null   | Authority and specific code of the data source (e.g., ["EPSG:####"](https://epsg.org/), ["IAU:#####"](http://www.opengis.net/def/crs/IAU/2015)) |
-| proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
-| proj:projjson    | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
-| proj:geometry    | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | Defines the footprint of this Item. |
-| proj:bbox        | \[number]       | Bounding box of the Item in the asset CRS in 2 or 3 dimensions. |
-| proj:centroid    | [Centroid Object](#centroid-object) | Coordinates representing the centroid of the Item (in lat/long) |
-| proj:shape       | \[integer]      | Number of pixels in Y and X directions for the default grid |
-| proj:transform   | \[number]       | The affine transformation coefficients for the default grid  |
+| Field Name     | Type          | Description |
+| -------------- | ------------- | ----------- |
+| proj:code      | string\|null  | Authority and specific code of the data source (e.g., ["EPSG:####"](https://epsg.org/), ["IAU:#####"](http://www.opengis.net/def/crs/IAU/2015)) |
+| proj:epsg      | integer\|null | **DEPRECATED.** [EPSG code](http://www.epsg-registry.org/) of the datasource |
+| proj:wkt2      | string\|null  | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
+| proj:projjson  | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
+| proj:geometry  | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | Defines the footprint of this Item. |
+| proj:bbox      | \[number]     | Bounding box of the Item in the asset CRS in 2 or 3 dimensions. |
+| proj:centroid  | [Centroid Object](#centroid-object) | Coordinates representing the centroid of the Item (in lat/long) |
+| proj:shape     | \[integer]    | Number of pixels in Y and X directions for the default grid |
+| proj:transform | \[number]     | The affine transformation coefficients for the default grid  |
 
 At least one of the fields MUST be specified, but it is RECOMMENDED to provide more information as detailed in the
-[Best Practices section](#best-practices) so that, for example, GDAL can read your data without issues. 
+[Best Practices section](#best-practices) so that, for example, GDAL can read your data without issues.
 
 Generally, it is preferrable to provide the projection information on the Asset level
 as they are specific to assets and may not apply to all assets.
@@ -60,32 +61,30 @@ filter for specific projection codes in an API. In this case you could override 
 
 #### proj:epsg
 
-**Notice**: This field has been removed in V2.0.0. See [proj:epsg Migration to V2](#projepsg-migration-to-projcode).
+This field has been deprecated in v1.2.0 in favor of `proj:code`.
+`proj:epsg` will be removed in v2.0.0 of this extension.
 
-#### proj:epsg migration to proj:code
-`proj:epsg` is removed in version 2.0.0 of this extension. Please use `proj:code`. For example, the following:
+For example, the following:
 
 ```json
 {
-  ...
   "proj:epsg": 32659,
-  ...
 }
 ```
+
 would be represented as:
+
 ```json
 {
-  ...
   "proj:code": "EPSG:32659",
-  ...
 }
 ```
 
 #### proj:code
 
-Projection codes are identified by a string. The [proj](https://proj.org/) library defines projections 
-using "authority:code", e.g., "EPSG:4326" or "IAU_2015:30100". Different projection authorities may define 
-different string formats. Examples of known projection authorities, where when can find well known codes that 
+Projection codes are identified by a string. The [proj](https://proj.org/) library defines projections
+using "authority:code", e.g., "EPSG:4326" or "IAU_2015:30100". Different projection authorities may define
+different string formats. Examples of known projection authorities, where when can find well known codes that
 clients are likely to support are listed in the following table.
 
 | Authority Name                          | URL                                                        |
@@ -96,6 +95,7 @@ clients are likely to support are listed in the following table.
 | ESRI                                    | <https://spatialreference.org/ref/esri/>                  |
 
 The `proj:code` field SHOULD be set to `null` in the following cases:
+
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid EPSG code for it. In this case, the CRS should be provided in `proj:wkt2` and/or `proj:projjson`.
   Clients can prefer to take either, although there may be discrepancies in how each might be interpreted.
@@ -106,16 +106,18 @@ A Coordinate Reference System (CRS) is the data reference system (sometimes call
 used by the asset data. This value is a [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string.
 
 This field SHOULD be set to `null` in the following cases:
+
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid WKT2 string for it.
 
 #### proj:projjson
 
 A Coordinate Reference System (CRS) is the data reference system (sometimes called a 'projection')
-used by the asset data. This value is a [PROJJSON](https://proj.org/specifications/projjson.html) object, 
+used by the asset data. This value is a [PROJJSON](https://proj.org/specifications/projjson.html) object,
 see the [JSON Schema](https://proj.org/schemas/v0.5/projjson.schema.json) for details.
 
 This field SHOULD be set to `null` in the following cases:
+
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid WKT2 string for it.
 
@@ -132,16 +134,16 @@ a square aligned to the original CRS grid.
 Bounding box of the assets represented by this Item in the asset data CRS. Specified as 4 or 6
 coordinates based on the CRS defined in the `proj:code`, `proj:projjson` or `proj:wkt2` fields.  First two numbers are coordinates
 of the lower left corner, followed by coordinates of upper right corner, , e.g., \[west, south, east, north],
-\[xmin, ymin, xmax, ymax], \[left, down, right, up], or \[west, south, lowest, east, north, highest]. 
+\[xmin, ymin, xmax, ymax], \[left, down, right, up], or \[west, south, lowest, east, north, highest].
 The length of the array must be 2\*n where n is the number of dimensions. The array contains all axes of the southwesterly
-most extent followed by all axes of the northeasterly most extent specified in Longitude/Latitude or Longitude/Latitude/Elevation 
-based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). When using 3D geometries, the elevation of the southwesterly most 
+most extent followed by all axes of the northeasterly most extent specified in Longitude/Latitude or Longitude/Latitude/Elevation
+based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). When using 3D geometries, the elevation of the southwesterly most
 extent is the minimum elevation in meters and the elevation of the northeasterly most extent is the maximum in meters.
 
 #### proj:centroid
 
-Coordinates representing the centroid of the Item. Coordinates are defined in latitude and longitude, even if 
-the data coordinate system does not use lat/long. This is to enable less sophisticated mapping tools to be able to render the 
+Coordinates representing the centroid of the Item. Coordinates are defined in latitude and longitude, even if
+the data coordinate system does not use lat/long. This is to enable less sophisticated mapping tools to be able to render the
 location of the Item, as some only handle points. Note that the centroid is best calculated in the native CRS and then projected
 into lat/long, as some projections can wrap the centroid location.
 
@@ -155,13 +157,13 @@ the default shape for all assets that don't have an overriding shape. This can b
 
 #### proj:transform
 
-Linear mapping from pixel coordinate space (Pixel, Line) to projection coordinate space (Xp, Yp). It is 
-a `3x3` matrix stored as a flat array of 9 elements in row major order. Since the last row is always `0,0,1` it can be omitted, 
+Linear mapping from pixel coordinate space (Pixel, Line) to projection coordinate space (Xp, Yp). It is
+a `3x3` matrix stored as a flat array of 9 elements in row major order. Since the last row is always `0,0,1` it can be omitted,
 in which case only 6 elements are recorded. This mapping can be obtained from 
 GDAL([`GetGeoTransform`](https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset15GetGeoTransformEPd), requires re-ordering)
-or the Rasterio ([`Transform`](https://rasterio.readthedocs.io/en/stable/api/rasterio.io.html#rasterio.io.BufferedDatasetWriter.transform)). 
-To get it on the command line you can use the [Rasterio CLI](https://rasterio.readthedocs.io/en/latest/cli.html) with the 
-[info](https://rasterio.readthedocs.io/en/latest/cli.html#info) command: `$ rio info`. 
+or the Rasterio ([`Transform`](https://rasterio.readthedocs.io/en/stable/api/rasterio.io.html#rasterio.io.BufferedDatasetWriter.transform)).
+To get it on the command line you can use the [Rasterio CLI](https://rasterio.readthedocs.io/en/latest/cli.html) with the
+[info](https://rasterio.readthedocs.io/en/latest/cli.html#info) command: `$ rio info`.
 
 ```txt
   [Xp]   [a0, a1, a2]   [Pixel]
@@ -192,29 +194,31 @@ This object represents the centroid of the Item Geometry.
 
 ## Best Practices
 
-There are several projection extension fields with potentially overlapping functionality. This section attempts to 
+There are several projection extension fields with potentially overlapping functionality. This section attempts to
 give an overview of which ones you should consider using. They fit into three general categories:
 
-- **Description of the coordinate reference system:** [proj:code](#projcode) is recommended, but it is just a 
-reference to known projection information. [WKT2](#projwkt2) and [PROJJSON](#projprojjson) are two options to 
-fully describe the projection information. 
+- **Description of the coordinate reference system:** [proj:code](#projcode) is recommended, but it is just a
+reference to known projection information. [WKT2](#projwkt2) and [PROJJSON](#projprojjson) are two options to
+fully describe the projection information.
 
-This is typically done for projections that aren't available or fully described in a known registry 
-(e.g., [EPSG Registry](https://epsg.org/) or [IAU Registry](http://www.opengis.net/def/crs/IAU/2015)). 
+This is typically done for projections that aren't available or fully described in a known registry
+(e.g., [EPSG Registry](https://epsg.org/) or [IAU Registry](http://www.opengis.net/def/crs/IAU/2015)).
 
 For example, the MODIS Sinusoidal projection does not have an EPSG code, but can be described using WKT2 or PROJJSON.
+
 - **Description of the native geometry information:** STAC requires the geometry and bounding box, but they are only available
-in lat/long (EPSG:4326, IAU_2015:30100, IAU_2015:49900, etc.). But most remote sensing data does not come in 
-that projection, so it is often useful for clients to have 
+in lat/long (EPSG:4326, IAU_2015:30100, IAU_2015:49900, etc.). But most remote sensing data does not come in
+that projection, so it is often useful for clients to have
 the geometry information ([geometry](#projgeometry), [bbox](#projbbox), [centroid](#projcentroid)) in the coordinate reference system
-of the asset's data, so it doesn't have to reproject (which can be lossy and takes time). 
+of the asset's data, so it doesn't have to reproject (which can be lossy and takes time).
 - **Information to enable cataloging of data without opening assets:** Often it is useful to be able to construct a 'virtual layer',
 like GDAL's [VRT](https://gdal.org/drivers/raster/vrt.html) without having to open the actual imagery file. [shape](#projshape) and
 [transform](#projtransform) together with the core description of the CRS provide enough information about the size and shape of
 the data in the file so that tools don't have to open it.
 
 For example, the GDAL implementation [requires](https://twitter.com/EvenRouault/status/1419752806735568902) 
-the following fields: 
+the following fields:
+
 1. `proj:wkt2` or `proj:projjson` (one of them filled with non-null values)
 2. Any of the following:
    - `proj:transform` and `proj:shape`
@@ -222,12 +226,12 @@ the following fields:
    - `proj:bbox` and `proj:shape`
 
 None of these are necessary for 'search' of data, the main use case of STAC. But all enable more 'cloud native' use of data, as they
- describe the metadata needed to stream data for processing and/or display on the web. We do recommend including at least the code if it's
-  available, as it's a fairly standard piece of metadata, and [see below](#crs-description-recommendations) for more
+describe the metadata needed to stream data for processing and/or display on the web. We do recommend including at least the code if it's
+available, as it's a fairly standard piece of metadata, and [see below](#crs-description-recommendations) for more
 information about when to use WKT and PROJJSON. We do recommend including the shape and transform fields if you have cloud
 optimized geotiff's or some other cloud native format, to enable online tools to work with the assets more efficiently. This is
-especially useful if the data is likely to be mosaiced or otherwise processed together, so that tools don't have to open every 
-single file to show or process aggregates of hundreds or thousands. Finally, the descriptions of the native geometry information 
+especially useful if the data is likely to be mosaiced or otherwise processed together, so that tools don't have to open every
+single file to show or process aggregates of hundreds or thousands. Finally, the descriptions of the native geometry information
 are useful when STAC is the complete metadata for an Item. If other metadata is also included it likely has this information, but
 we provide it because some modern systems are just using STAC for their entire metadata description.
 
@@ -235,14 +239,15 @@ we provide it because some modern systems are just using STAC for their entire m
 
 WKT2 and PROJJSON are mostly recommended when you have data that is not part of a standard registry. Providing one of them
 supplies the exact information for projection software to do the exact projection transform.
-WKT2 and PROJJSON are equivalent to one another - more clients understand WKT2, but PROJJSON fits more nicely in the STAC JSON 
-structure, since they are both JSON. For now it's probably best to use both for maximum interoperability, but just using PROJJSON 
+WKT2 and PROJJSON are equivalent to one another - more clients understand WKT2, but PROJJSON fits more nicely in the STAC JSON
+structure, since they are both JSON. For now it's probably best to use both for maximum interoperability, but just using PROJJSON
 is likely ok if you aren't worried about legacy client support.
 
 ### Thumbnails
 
 For (unlocated) thumbnails and similar imagery, it is recommended set `proj:code` to `null` and include `proj:shape`
 so that
+
 1. clients can read the image dimensions upfront (and reserve space for them), and
 2. you explicitly state that the thumbnail is not geolocated.
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ The fields in the table below can be used in these parts of STAC documents:
 
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
-| proj:epsg        | integer\|null   | [EPSG code](http://www.epsg-registry.org/) of the datasource; Maintained for backwards compatability and will be deprecated in V2.0.0. Please use `proj:authority` and `proj:code`. |
-| proj:code        | string\|null   | Authority specific code of the data source (e.g., [EPSG](http://www.epsg-registry.org/), [IAU](http://www.opengis.net/def/crs/IAU/2015)) |
-| proj:authority   | string\|null    | The name of the authority that designated the `proj:code` of the datasource. Known authorities are identified by the [OGC](http://www.opengis.net/def/crs/) and include: `OGC`, `EPSG`, `IAU`, and `COSMO`.|
+| proj:epsg        | integer\|null   | [EPSG code](http://www.opengis.net/def/crs/EPSG) of the datasource; Maintained for backwards compatability and will be deprecated in V2.0.0. Please use `proj:authority` and `proj:code`. |
+| proj:code        | string\|null   | Authority specific code of the data source (e.g., [EPSG](http://www.opengis.net/def/crs/EPSG), [IAU](http://www.opengis.net/def/crs/IAU/2015)) |
+| proj:authority   | string\|null    | The name of the authority that designated the `proj:code` of the datasource. Known authorities are identified [below](#projauthority).|
 | proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:geometry    | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | Defines the footprint of this Item. |
@@ -105,7 +105,13 @@ would be represented as:
 The projection authority is some domain governing body that defines  projections. 
 The contents of this field are permissive and any string can be provided. In practice, it is preferable 
 to use a known authority. 
-Examples include `epsg`, `iau_2015`, and `ogc`.
+
+| Authority Name | proj:authority | URL |
+| -------------- | -------------- | --- |
+| COSMO          | `cosmo`          |     |
+| European Petroleum Survey Groups (EPSG) | `epsg` | http://www.opengis.net/def/crs/EPSG |
+| International Astronomical Union (IAU) | `iau` | http://www.opengis.net/def/crs/IAU/2015 |
+| Open Geospatial Consortium (OGC) | `ogc` | http://www.opengis.net/def/crs/OGC |
 
 Specifying this field requires that the `proj:code` field also be specified.
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ The fields in the table below can be used in these parts of STAC documents:
 
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
-| proj:epsg        | integer   | [EPSG code](http://www.epsg-registry.org/) of the datasource; Maintained for backwards compatability and will be deprecated in V2.0.0. Please use `proj:authority` and `proj:code`. |
-| proj:code        | string   | [EPSG code](http://www.epsg-registry.org/) or other code (e.g., [IAU](http://voparis-vespa-crs.obspm.fr:8080/web/2015.html)) of the datasource |
-| proj:authority   | string    | The name of the authority that designated the proj:code of the datasource. |
+| proj:epsg        | integer\|null   | [EPSG code](http://www.epsg-registry.org/) of the datasource; Maintained for backwards compatability and will be deprecated in V2.0.0. Please use `proj:authority` and `proj:code`. |
+| proj:code        | string\|null   | [EPSG code](http://www.epsg-registry.org/) or other code (e.g., [IAU](http://voparis-vespa-crs.obspm.fr:8080/web/2015.html)) of the datasource |
+| proj:authority   | string\|null    | The name of the authority that designated the proj:code of the datasource. |
 | proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:geometry    | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | Defines the footprint of this Item. |
@@ -64,13 +64,11 @@ You may want to add the EPSG code to the Item Properties though as this would pr
 filter for specific EPSG codes in an API.
 In this case you could override the EPSG code for the thumbnail on the asset level.
 
-The projection authority is some domain governing body that defines commonly used projections. 
-The contents of this field are permissive and any string can be provided. In practice, it is preferable to use a known authority. 
-Examples include: `epsg`, `iau_2015`, or `ogc`.
-
 ### Additional Field Information
 
 #### proj:epsg
+
+**Notice**: This field will be deprecated in V2.0.0. See [proj:epsg Migration to V2](#projepsg-migration-to-v2).
 
 A Coordinate Reference System (CRS) is the data reference system (sometimes called a
 'projection') used by the asset data, and can usually be referenced using an 
@@ -81,6 +79,46 @@ This field SHOULD be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid EPSG code for it. In this case, the CRS should be provided in `proj:wkt2` and/or `proj:projjson`.
   Clients can prefer to take either, although there may be discrepancies in how each might be interpreted.
+
+#### proj:epsg Migration to V2
+`proj:epsg` will be deprecated in version 2.0.0 of this extension. Please use `proj:code` and `proj:authority`. For example, the following:
+
+```json
+{
+  ...
+  "proj:epsg": 32659,
+  ...
+}
+```
+would be represented as:
+```json
+{
+  ...
+  "proj:authority": "epsg",
+  "proj:code": 32659,
+  ...
+}
+```
+
+#### proj:authority
+
+The projection authority is some domain governing body that defines commonly used projections. 
+The contents of this field are permissive and any string can be provided. In practice, it is preferable 
+to use a known authority. 
+Examples include: `epsg`, `iau_2015`, or `ogc`.
+
+Specifying this field requires that the `proj:code` field also be specified.
+
+This field should be set to `null` in the following cases:
+- The projection authority is unknown. 
+#### proj:code
+
+Each authority identifies projections by a unique code. For example, WGS84 is identified by the EPSG authority using the 4326 code. 
+
+Specifying this field requires that the `proj:authority` field also be specified.
+
+This field should be set to `null` in the following cases:
+- The projection code is unknown.
 
 #### proj:wkt2
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In this case you could override the `proj:srid` for the thumbnail on the asset l
 
 #### proj:epsg
 
-**Notice**: This field has been removed in V2.0.0. See [proj:epsg Migration to V2](#projepsg-migration-projsrid).
+**Notice**: This field has been removed in V2.0.0. See [proj:epsg Migration to V2](#projepsg-migration-to-projsrid).
 
 #### proj:epsg Migration to proj:srid
 `proj:epsg` is removed in version 2.0.0 of this extension. Please use `proj:srid`. For example, the following:
@@ -197,7 +197,8 @@ This is typically done for projections that aren't available or fully described 
 
 For example, the MODIS Sinusoidal projection does not have an EPSG code, but can be described using WKT2 or PROJJSON.
 - **Description of the native geometry information:** STAC requires the geometry and bounding box, but they are only available
-in lat/long (EPSG:4326, IAU_2015:30100, IAU_2015:49900, etc.). But most remote sensing data does not come in that projection, so it is often useful for clients to have 
+in lat/long (EPSG:4326, IAU_2015:30100, IAU_2015:49900, etc.). But most remote sensing data does not come in 
+that projection, so it is often useful for clients to have 
 the geometry information ([geometry](#projgeometry), [bbox](#projbbox), [centroid](#projcentroid)) in the coordinate reference system
 of the asset's data, so it doesn't have to reproject (which can be lossy and takes time). 
 - **Information to enable cataloging of data without opening assets:** Often it is useful to be able to construct a 'virtual layer',
@@ -205,14 +206,17 @@ like GDAL's [VRT](https://gdal.org/drivers/raster/vrt.html) without having to op
 [transform](#projtransform) together with the core description of the CRS provide enough information about the size and shape of
 the data in the file so that tools don't have to open it.
 
-For example, the GDAL implementation [requires](https://twitter.com/EvenRouault/status/1419752806735568902) the following fields: 
+For example, the GDAL implementation [requires](https://twitter.com/EvenRouault/status/1419752806735568902) 
+the following fields: 
 1. `proj:wkt2` or `proj:projjson` (one of them filled with non-null values)
 2. Any of the following:
    - `proj:transform` and `proj:shape`
    - `proj:transform` and `proj:bbox`
    - `proj:bbox` and `proj:shape`
 
-None of these are necessary for 'search' of data, the main use case of STAC. But all enable more 'cloud native' use of data, as they describe the metadata needed to stream data for processing and/or display on the web. We do recommend including at least the code if it's available, as it's a fairly standard piece of metadata, and [see below](#crs-description-recommendations) for more
+None of these are necessary for 'search' of data, the main use case of STAC. But all enable more 'cloud native' use of data, as they
+ describe the metadata needed to stream data for processing and/or display on the web. We do recommend including at least the code if it's
+  available, as it's a fairly standard piece of metadata, and [see below](#crs-description-recommendations) for more
 information about when to use WKT and PROJJSON. We do recommend including the shape and transform fields if you have cloud
 optimized geotiff's or some other cloud native format, to enable online tools to work with the assets more efficiently. This is
 especially useful if the data is likely to be mosaiced or otherwise processed together, so that tools don't have to open every 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ filter for specific projection codes in an API. In this case you could override 
 
 **Notice**: This field has been removed in V2.0.0. See [proj:epsg Migration to V2](#projepsg-migration-to-projcode).
 
-#### proj:epsg Migration to proj:code
+#### proj:epsg migration to proj:code
 `proj:epsg` is removed in version 2.0.0 of this extension. Please use `proj:code`. For example, the following:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The fields in the table below can be used in these parts of STAC documents:
 | ---------------- | ------------------------ | ----------- |
 | proj:epsg        | integer\|null   | [EPSG code](http://www.epsg-registry.org/) of the datasource; Maintained for backwards compatability and will be deprecated in V2.0.0. Please use `proj:authority` and `proj:code`. |
 | proj:code        | string\|null   | [EPSG code](http://www.epsg-registry.org/) or other code (e.g., [IAU](http://voparis-vespa-crs.obspm.fr:8080/web/2015.html)) of the datasource |
-| proj:authority   | string\|null    | The name of the authority that designated the proj:code of the datasource. |
+| proj:authority   | string\|null    | The name of the authority that designated the `proj:code` of the datasource. |
 | proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:geometry    | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | Defines the footprint of this Item. |

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ The fields in the table below can be used in these parts of STAC documents:
 
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
-| proj:epsg        | integer\|null   | [EPSG code](http://www.epsg-registry.org/) of the datasource; Maintained for backwards compatability. Please use `proj:authority` and `proj:code`. |
-| proj:code        | integer\|null   | **REQUIRED.** [EPSG code](http://www.epsg-registry.org/) or other code (e.g., [IAU](http://voparis-vespa-crs.obspm.fr:8080/web/2015.html)) of the datasource |
-| proj:authority   | string\|null    | The name of the authority that designated the proj:code of the datasource. Default: `epsg`. |
+| proj:epsg        | string   | [EPSG code](http://www.epsg-registry.org/) of the datasource; Maintained for backwards compatability. Please use `proj:authority` and `proj:code`. |
+| proj:code        | string   | [EPSG code](http://www.epsg-registry.org/) or other code (e.g., [IAU](http://voparis-vespa-crs.obspm.fr:8080/web/2015.html)) of the datasource |
+| proj:authority   | string    | The name of the authority that designated the proj:code of the datasource. |
 | proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:geometry    | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | Defines the footprint of this Item. |

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ The fields in the table below can be used in these parts of STAC documents:
 
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
+| proj:epsg        | integer\|null   | [EPSG code](http://www.epsg-registry.org/) of the datasource; Maintained for backwards compatability. Please use `proj:authority` and `proj:code`. |
 | proj:code        | integer\|null   | **REQUIRED.** [EPSG code](http://www.epsg-registry.org/) or other code (e.g., [IAU](http://voparis-vespa-crs.obspm.fr:8080/web/2015.html)) of the datasource |
 | proj:authority   | string\|null    | The name of the authority that designated the proj:code of the datasource. Default: `epsg`. |
-| proj:epsg        | integer\|null   |  [EPSG code](http://www.epsg-registry.org/) of the datasource; Maintained for backwards compatability. Please use `proj:authority` and `proj:code`. |
 | proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:geometry    | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | Defines the footprint of this Item. |

--- a/README.md
+++ b/README.md
@@ -88,17 +88,16 @@ using "authority:code", e.g., "EPSG:4326" or "IAU_2015:30100". Different project
 different string formats. Examples of known projection authorities, where when can find well known codes that 
 clients are likely to support are listed in the following table.
 
-| Authority Name | URL |
-| -------------- |  --- |
-| European Petroleum Survey Groups (EPSG) |  http://www.opengis.net/def/crs/EPSG or http://epsg.org |
-| International Astronomical Union (IAU) | http://www.opengis.net/def/crs/IAU/2015 |
-| Open Geospatial Consortium (OGC) |  http://www.opengis.net/def/crs/OGC |
+| Authority Name                          | URL                                                        |
+| --------------------------------------- | ---------------------------------------------------------- |
+| European Petroleum Survey Groups (EPSG) | <http://www.opengis.net/def/crs/EPSG> or <http://epsg.org> |
+| International Astronomical Union (IAU)  | <http://www.opengis.net/def/crs/IAU/2015>                  |
+| Open Geospatial Consortium (OGC)        | <http://www.opengis.net/def/crs/OGC>                       |
 
 The `proj:code` field SHOULD be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid EPSG code for it. In this case, the CRS should be provided in `proj:wkt2` and/or `proj:projjson`.
   Clients can prefer to take either, although there may be discrepancies in how each might be interpreted.
-
 
 #### proj:wkt2
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In this case you could override the `proj:srid` for the thumbnail on the asset l
 
 #### proj:epsg
 
-**Notice**: This field has been removed in V2.0.0. See [proj:epsg Migration to V2](#projepsg-migration-to-v2).
+**Notice**: This field has been removed in V2.0.0. See [proj:epsg Migration to V2](#projepsg-migration-projsrid).
 
 #### proj:epsg Migration to proj:srid
 `proj:epsg` is removed in version 2.0.0 of this extension. Please use `proj:srid`. For example, the following:
@@ -84,7 +84,9 @@ would be represented as:
 
 #### proj:srid
 
-Projection codes are identified by a string. The [proj](https://proj.org/) library defines projections using "authority:code", e.g., "EPSG:4326" or "IAU_2015:30100". Different projection authorities may define different string formats.
+Projection codes are identified by a string. The [proj](https://proj.org/) library defines projections 
+using "authority:code", e.g., "EPSG:4326" or "IAU_2015:30100". Different projection authorities may define 
+different string formats.
 
 The `proj:srid` field SHOULD be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
@@ -186,8 +188,13 @@ This object represents the centroid of the Item Geometry.
 There are several projection extension fields with potentially overlapping functionality. This section attempts to 
 give an overview of which ones you should consider using. They fit into three general categories:
 
-- **Description of the coordinate reference system:** [proj:srid](#proj:srid) is recommended, but it is just a reference to known projection information. [WKT2](#projwkt2) and [PROJJSON](#projprojjson) are two options to fully describe the projection information. 
-This is typically done for projections that aren't available or fully described in a known registry (e.g., [EPSG Registry](https://epsg.org/) or [IAU Registry](http://www.opengis.net/def/crs/IAU/2015)). 
+- **Description of the coordinate reference system:** [proj:srid](#projsrid) is recommended, but it is just a 
+reference to known projection information. [WKT2](#projwkt2) and [PROJJSON](#projprojjson) are two options to 
+fully describe the projection information. 
+
+This is typically done for projections that aren't available or fully described in a known registry 
+(e.g., [EPSG Registry](https://epsg.org/) or [IAU Registry](http://www.opengis.net/def/crs/IAU/2015)). 
+
 For example, the MODIS Sinusoidal projection does not have an EPSG code, but can be described using WKT2 or PROJJSON.
 - **Description of the native geometry information:** STAC requires the geometry and bounding box, but they are only available
 in lat/long (EPSG:4326, IAU_2015:30100, IAU_2015:49900, etc.). But most remote sensing data does not come in that projection, so it is often useful for clients to have 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ The fields in the table below can be used in these parts of STAC documents:
 
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
-| proj:epsg        | integer\|null   | [EPSG code](http://www.epsg-registry.org/) of the datasource |
+| proj:code        | integer\|null   | **REQUIRED.** [EPSG code](http://www.epsg-registry.org/) or other code (e.g., [IAU](http://voparis-vespa-crs.obspm.fr:8080/web/2015.html)) of the datasource |
+| proj:authority   | string\|null    | The name of the authority that designated the proj:code of the datasource. Default: `epsg`. |
+| proj:epsg        | integer\|null   |  [EPSG code](http://www.epsg-registry.org/) of the datasource; Maintained for backwards compatability. Please use `proj:authority` and `proj:code`. |
 | proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:geometry    | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | Defines the footprint of this Item. |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The fields in the table below can be used in these parts of STAC documents:
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
 | proj:epsg        | integer\|null   | [EPSG code](http://www.epsg-registry.org/) of the datasource; Maintained for backwards compatability and will be deprecated in V2.0.0. Please use `proj:authority` and `proj:code`. |
-| proj:code        | string\|null   | [EPSG code](http://www.epsg-registry.org/) or other code (e.g., [IAU](http://voparis-vespa-crs.obspm.fr:8080/web/2015.html)) of the datasource |
+| proj:code        | string\|null   | Authority specific code of the data source (e.g., [EPSG](http://www.epsg-registry.org/), [IAU](http://voparis-vespa-crs.obspm.fr:8080/web/2015.html)) |
 | proj:authority   | string\|null    | The name of the authority that designated the `proj:code` of the datasource. |
 | proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
@@ -102,18 +102,19 @@ would be represented as:
 
 #### proj:authority
 
-The projection authority is some domain governing body that defines commonly used projections. 
+The projection authority is some domain governing body that defines  projections. 
 The contents of this field are permissive and any string can be provided. In practice, it is preferable 
 to use a known authority. 
-Examples include: `epsg`, `iau_2015`, or `ogc`.
+Examples include `epsg`, `iau_2015`, and `ogc`.
 
 Specifying this field requires that the `proj:code` field also be specified.
 
 This field should be set to `null` in the following cases:
 - The projection authority is unknown. 
+
 #### proj:code
 
-Each authority identifies projections by a unique code. For example, WGS84 is identified by the EPSG authority using the 4326 code. 
+Each authority identifies projections by a unique code. For example, WGS84 is identified by the EPSG authority using the code `4326`. 
 
 Specifying this field requires that the `proj:authority` field also be specified.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ A Coordinate Reference System (CRS) is the data reference system (sometimes call
 [EPSG code](https://en.wikipedia.org/wiki/EPSG_Geodetic_Parameter_Dataset).
 A great tool to help find EPSG codes is [epsg.io](http://epsg.io/).
 
-This field SHOULD be set to `null` in the following cases:
+This field must be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid EPSG code for it. In this case, the CRS should be provided in `proj:wkt2` and/or `proj:projjson`.
   Clients can prefer to take either, although there may be discrepancies in how each might be interpreted.
@@ -82,7 +82,7 @@ This field SHOULD be set to `null` in the following cases:
 A Coordinate Reference System (CRS) is the data reference system (sometimes called a 'projection')
 used by the asset data. This value is a [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string.
 
-This field SHOULD be set to `null` in the following cases:
+This field should be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid WKT2 string for it.
 
@@ -92,7 +92,7 @@ A Coordinate Reference System (CRS) is the data reference system (sometimes call
 used by the asset data. This value is a [PROJJSON](https://proj.org/specifications/projjson.html) object, 
 see the [JSON Schema](https://proj.org/schemas/v0.5/projjson.schema.json) for details.
 
-This field SHOULD be set to `null` in the following cases:
+This field should be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
 - A CRS exists, but there is no valid WKT2 string for it.
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ The fields in the table below can be used in these parts of STAC documents:
 
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
-| proj:epsg        | integer\|null   | [EPSG code](https://epsg.org/) of the datasource; Maintained for backwards compatability and will be deprecated in V2.0.0. Please use `proj:authority` and `proj:code`. |
-| proj:code        | string\|null   | Authority specific code of the data source (e.g., [EPSG](https://epsg.org/), [IAU](http://www.opengis.net/def/crs/IAU/2015)) |
-| proj:authority   | string\|null    | The name of the authority that designated the `proj:code` of the datasource. Known authorities are identified [below](#projauthority).|
+| proj:code        | string\|null   | Authority and specific code of the data source (e.g., ["EPSG:####"](https://epsg.org/), ["IAU:#####"](http://www.opengis.net/def/crs/IAU/2015)) |
 | proj:wkt2        | string\|null    | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/specifications/projjson.html)\|null | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:geometry    | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | Defines the footprint of this Item. |
@@ -52,36 +50,22 @@ At least one of the fields MUST be specified, but it is RECOMMENDED to provide m
 [Best Practices section](#best-practices) so that, for example, GDAL can read your data without issues. 
 If specifying `proj:code` or `proj:authority`, both fields MUST be specified.
 
-Also, [version 1.0.0](https://github.com/stac-extensions/projection/releases/tag/v1.0.0) of this extension
-required `proj:epsg` (either as integer or null) in Item Properties.
-This is not required anymore, but it is still recommended to additionally provide an EPSG code whenever available.
-
 Generally, it is preferrable to provide the projection information on the Asset level
 as they are specific to assets and may not apply to all assets.
 For example, if you provide a smaller and unlocated thumbnail, having the projection information in the Item Properties
 would imply that the projection information also applies to the thumbnail if not specified otherwise in the asset.
-You may want to add the EPSG code to the Item Properties though as this would provide an easy way to
-filter for specific EPSG codes in an API.
-In this case you could override the EPSG code for the thumbnail on the asset level.
+You may want to add the `proj:code`` to the Item Properties though as this would provide an easy way to
+filter for specific projection codes in an API.
+In this case you could override the `proj:code` for the thumbnail on the asset level.
 
 ### Additional Field Information
 
 #### proj:epsg
 
-**Notice**: This field will be deprecated in V2.0.0. See [proj:epsg Migration to V2](#projepsg-migration-to-v2).
+**Notice**: This field has been removed in V2.0.0. See [proj:epsg Migration to V2](#projepsg-migration-to-v2).
 
-A Coordinate Reference System (CRS) is the data reference system (sometimes called a
-'projection') used by the asset data, and can usually be referenced using an 
-[EPSG code](https://en.wikipedia.org/wiki/EPSG_Geodetic_Parameter_Dataset).
-A great tool to help find EPSG codes is [epsg.io](http://epsg.io/).
-
-This field SHOULD be set to `null` in the following cases:
-- The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
-- A CRS exists, but there is no valid EPSG code for it. In this case, the CRS should be provided in `proj:wkt2` and/or `proj:projjson`.
-  Clients can prefer to take either, although there may be discrepancies in how each might be interpreted.
-
-#### proj:epsg Migration to V2
-`proj:epsg` will be deprecated in version 2.0.0 of this extension. Please use `proj:code` and `proj:authority`. For example, the following:
+#### proj:epsg Migration to proj:code
+`proj:epsg` is removed in version 2.0.0 of this extension. Please use `proj:code`. For example, the following:
 
 ```json
 {
@@ -94,38 +78,19 @@ would be represented as:
 ```json
 {
   ...
-  "proj:authority": "epsg",
-  "proj:code": 32659,
+  "proj:code": "EPSG:32659",
   ...
 }
 ```
 
-#### proj:authority
-
-The projection authority is some domain governing body that defines  projections. 
-The contents of this field are permissive and any string can be provided. In practice, it is preferable 
-to use a known authority. 
-
-| Authority Name | proj:authority | URL |
-| -------------- | -------------- | --- |
-| COSMO          | `cosmo`          |     |
-| European Petroleum Survey Groups (EPSG) | `epsg` | http://www.opengis.net/def/crs/EPSG |
-| International Astronomical Union (IAU) | `iau` | http://www.opengis.net/def/crs/IAU/2015 |
-| Open Geospatial Consortium (OGC) | `ogc` | http://www.opengis.net/def/crs/OGC |
-
-Specifying this field requires that the `proj:code` field also be specified.
-
-This field should be set to `null` in the following cases:
-- The projection authority is unknown. 
-
 #### proj:code
 
-Each authority identifies projections by a unique code. For example, WGS84 is identified by the EPSG authority using the code `4326`. 
+Projection codes are identified by a string. The [proj](https://proj.org/) library defines projections using "authority:code", e.g., "EPSG:4326" or "IAU_2015:30100". Different projection authorities may define different string formats.
 
-Specifying this field requires that the `proj:authority` field also be specified.
-
-This field should be set to `null` in the following cases:
-- The projection code is unknown.
+The `proj:code` field SHOULD be set to `null` in the following cases:
+- The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
+- A CRS exists, but there is no valid EPSG code for it. In this case, the CRS should be provided in `proj:wkt2` and/or `proj:projjson`.
+  Clients can prefer to take either, although there may be discrepancies in how each might be interpreted.
 
 #### proj:wkt2
 
@@ -150,14 +115,14 @@ This field SHOULD be set to `null` in the following cases:
 
 A GeoJSON Geometry object as defined in [RFC 7946, sections 3.1](https://tools.ietf.org/html/rfc7946)
 representing the footprint of this Item, except not necessarily in EPSG:4326 as required by RFC7946.
-Specified based on the `proj:epsg`, `proj:projjson` or `proj:wkt2` fields (not necessarily EPSG:4326).
+Specified based on the `proj:code`, `proj:projjson` or `proj:wkt2` fields (not necessarily EPSG:4326).
 Usually, this will be represented by a Polygon with five coordinates, as the item in the asset data CRS should be
 a square aligned to the original CRS grid.
 
 #### proj:bbox
 
 Bounding box of the assets represented by this Item in the asset data CRS. Specified as 4 or 6
-coordinates based on the CRS defined in the `proj:epsg`, `proj:projjson` or `proj:wkt2` fields.  First two numbers are coordinates
+coordinates based on the CRS defined in the `proj:code`, `proj:projjson` or `proj:wkt2` fields.  First two numbers are coordinates
 of the lower left corner, followed by coordinates of upper right corner, , e.g., \[west, south, east, north],
 \[xmin, ymin, xmax, ymax], \[left, down, right, up], or \[west, south, lowest, east, north, highest]. 
 The length of the array must be 2\*n where n is the number of dimensions. The array contains all axes of the southwesterly
@@ -222,12 +187,11 @@ This object represents the centroid of the Item Geometry.
 There are several projection extension fields with potentially overlapping functionality. This section attempts to 
 give an overview of which ones you should consider using. They fit into three general categories:
 
-- **Description of the coordinate reference system:** [EPSG code](#projepsg) is recommended, but it is just a reference to known
-projection information. [WKT2](#projwkt2) and [PROJJSON](#projprojjson) are two options to fully describe the projection information. 
-This is typically done for projections that aren't available or fully described in the [EPSG Registry](https://epsg.org/). 
+- **Description of the coordinate reference system:** [proj:code](#proj:code) is recommended, but it is just a reference to known projection information. [WKT2](#projwkt2) and [PROJJSON](#projprojjson) are two options to fully describe the projection information. 
+This is typically done for projections that aren't available or fully described in a known registry (e.g., [EPSG Registry](https://epsg.org/) or [IAU Registry](http://www.opengis.net/def/crs/IAU/2015)). 
 For example, the MODIS Sinusoidal projection does not have an EPSG code, but can be described using WKT2 or PROJJSON.
 - **Description of the native geometry information:** STAC requires the geometry and bounding box, but they are only available
-in lat/long (EPSG:4326). But most remote sensing data does not come in that projection, so it is often useful for clients to have 
+in lat/long (EPSG:4326, IAU_2015:30100, IAU_2015:49900, etc.). But most remote sensing data does not come in that projection, so it is often useful for clients to have 
 the geometry information ([geometry](#projgeometry), [bbox](#projbbox), [centroid](#projcentroid)) in the coordinate reference system
 of the asset's data, so it doesn't have to reproject (which can be lossy and takes time). 
 - **Information to enable cataloging of data without opening assets:** Often it is useful to be able to construct a 'virtual layer',
@@ -236,15 +200,13 @@ like GDAL's [VRT](https://gdal.org/drivers/raster/vrt.html) without having to op
 the data in the file so that tools don't have to open it.
 
 For example, the GDAL implementation [requires](https://twitter.com/EvenRouault/status/1419752806735568902) the following fields: 
-1. `proj:epsg`, `proj:wkt2` or `proj:projjson` (one of them filled with non-null values)
+1. `proj:wkt2` or `proj:projjson` (one of them filled with non-null values)
 2. Any of the following:
    - `proj:transform` and `proj:shape`
    - `proj:transform` and `proj:bbox`
    - `proj:bbox` and `proj:shape`
 
-None of these are necessary for 'search' of data, the main use case of STAC. But all enable more 'cloud native' use of data,
-as they describe the metadata needed to stream data for processing and/or display on the web. We do recommend including at least the
-EPSG code if it's available, as it's a fairly standard piece of metadata, and [see below](#crs-description-recommendations) for more
+None of these are necessary for 'search' of data, the main use case of STAC. But all enable more 'cloud native' use of data, as they describe the metadata needed to stream data for processing and/or display on the web. We do recommend including at least the code if it's available, as it's a fairly standard piece of metadata, and [see below](#crs-description-recommendations) for more
 information about when to use WKT and PROJJSON. We do recommend including the shape and transform fields if you have cloud
 optimized geotiff's or some other cloud native format, to enable online tools to work with the assets more efficiently. This is
 especially useful if the data is likely to be mosaiced or otherwise processed together, so that tools don't have to open every 
@@ -254,7 +216,7 @@ we provide it because some modern systems are just using STAC for their entire m
 
 ### CRS Description Recommendations
 
-WKT2 and PROJJSON are mostly recommended when you have data that is not part of the standard EPSG registry. Providing one of them
+WKT2 and PROJJSON are mostly recommended when you have data that is not part of a standard registry. Providing one of them
 supplies the exact information for projection software to do the exact projection transform.
 WKT2 and PROJJSON are equivalent to one another - more clients understand WKT2, but PROJJSON fits more nicely in the STAC JSON 
 structure, since they are both JSON. For now it's probably best to use both for maximum interoperability, but just using PROJJSON 
@@ -262,7 +224,7 @@ is likely ok if you aren't worried about legacy client support.
 
 ### Thumbnails
 
-For (unlocated) thumbnails and similar imagery, it is recommended set `proj:epsg` to `null` and include `proj:shape`
+For (unlocated) thumbnails and similar imagery, it is recommended set `proj:code` to `null` and include `proj:shape`
 so that
 1. clients can read the image dimensions upfront (and reserve space for them), and
 2. you explicitly state that the thumbnail is not geolocated.

--- a/examples/assets.json
+++ b/examples/assets.json
@@ -43,7 +43,7 @@
     "created": "2020-12-12T01:48:13.725Z",
     "updated": "2020-12-12T01:48:13.725Z",
     "platform": "cool_sat2",
-    "proj:epsg": null,
+    "proj:epsg": 32659,
     "instruments": [
       "cool_sensor_v1"
     ]
@@ -84,6 +84,11 @@
     "thumbnail": {
       "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",
       "title": "Thumbnail",
+      "proj:epsg": null,
+      "proj:shape": [
+        800,
+        800
+      ],
       "type": "image/png",
       "roles": [
         "thumbnail"

--- a/examples/assets.json
+++ b/examples/assets.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "20201211_223832_CS2_A",

--- a/examples/assets.json
+++ b/examples/assets.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
   ],
   "type": "Feature",
   "id": "20201211_223832_CS2_A",
@@ -43,7 +43,7 @@
     "created": "2020-12-12T01:48:13.725Z",
     "updated": "2020-12-12T01:48:13.725Z",
     "platform": "cool_sat2",
-    "proj:epsg": 32659,
+    "proj:epsg": null,
     "instruments": [
       "cool_sensor_v1"
     ]
@@ -84,11 +84,6 @@
     "thumbnail": {
       "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",
       "title": "Thumbnail",
-      "proj:epsg": null,
-      "proj:shape": [
-        800,
-        800
-      ],
       "type": "image/png",
       "roles": [
         "thumbnail"

--- a/examples/assets.json
+++ b/examples/assets.json
@@ -43,7 +43,8 @@
     "created": "2020-12-12T01:48:13.725Z",
     "updated": "2020-12-12T01:48:13.725Z",
     "platform": "cool_sat2",
-    "proj:epsg": 32659,
+    "proj:code": 32659,
+    "proj:authority": "epsg",
     "instruments": [
       "cool_sensor_v1"
     ]
@@ -64,7 +65,8 @@
         "data"
       ],
       "gsd": 0.66,
-      "proj:epsg": 32659,
+      "proj:code": 32659,
+      "proj:authority": "epsg",
       "proj:shape": [
         5558,
         9559
@@ -84,7 +86,8 @@
     "thumbnail": {
       "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",
       "title": "Thumbnail",
-      "proj:epsg": null,
+      "proj:code": null,
+      "proj:authority": null,
       "proj:shape": [
         800,
         800

--- a/examples/assets.json
+++ b/examples/assets.json
@@ -43,8 +43,7 @@
     "created": "2020-12-12T01:48:13.725Z",
     "updated": "2020-12-12T01:48:13.725Z",
     "platform": "cool_sat2",
-    "proj:code": 32659,
-    "proj:authority": "epsg",
+    "proj:srid": "EPSG:32659",
     "instruments": [
       "cool_sensor_v1"
     ]
@@ -65,8 +64,7 @@
         "data"
       ],
       "gsd": 0.66,
-      "proj:code": 32659,
-      "proj:authority": "epsg",
+      "proj:srid": "EPSG:32659",
       "proj:shape": [
         5558,
         9559
@@ -86,8 +84,7 @@
     "thumbnail": {
       "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",
       "title": "Thumbnail",
-      "proj:code": null,
-      "proj:authority": null,
+      "proj:srid": null,
       "proj:shape": [
         800,
         800

--- a/examples/assets.json
+++ b/examples/assets.json
@@ -43,7 +43,7 @@
     "created": "2020-12-12T01:48:13.725Z",
     "updated": "2020-12-12T01:48:13.725Z",
     "platform": "cool_sat2",
-    "proj:srid": "EPSG:32659",
+    "proj:code": "EPSG:32659",
     "instruments": [
       "cool_sensor_v1"
     ]
@@ -64,7 +64,7 @@
         "data"
       ],
       "gsd": 0.66,
-      "proj:srid": "EPSG:32659",
+      "proj:code": "EPSG:32659",
       "proj:shape": [
         5558,
         9559
@@ -84,7 +84,7 @@
     "thumbnail": {
       "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",
       "title": "Thumbnail",
-      "proj:srid": null,
+      "proj:code": null,
       "proj:shape": [
         800,
         800

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -28,7 +28,8 @@
         "data"
       ],
       "gsd": 0.66,
-      "proj:epsg": 32659,
+      "proj:code": 32659,
+      "proj:authority": "epsg",
       "proj:shape": [
         5558,
         9559
@@ -56,8 +57,12 @@
     "gsd": [
       0.66
     ],
-    "proj:epsg": [
+    "proj:code": [
       32659,
+      null
+    ],
+    "proj:authority": [
+      "epsg",
       null
     ]
   },

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
     "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
   ],
   "type": "Collection",

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
   ],
   "type": "Collection",

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -28,7 +28,7 @@
         "data"
       ],
       "gsd": 0.66,
-      "proj:srid": "EPSG:32659",
+      "proj:code": "EPSG:32659",
       "proj:shape": [
         5558,
         9559
@@ -56,7 +56,7 @@
     "gsd": [
       0.66
     ],
-    "proj:srid": [
+    "proj:code": [
       32659,
       null
     ]

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -28,8 +28,7 @@
         "data"
       ],
       "gsd": 0.66,
-      "proj:code": 32659,
-      "proj:authority": "epsg",
+      "proj:srid": "EPSG:32659",
       "proj:shape": [
         5558,
         9559
@@ -57,12 +56,8 @@
     "gsd": [
       0.66
     ],
-    "proj:code": [
+    "proj:srid": [
       32659,
-      null
-    ],
-    "proj:authority": [
-      "epsg",
       null
     ]
   },

--- a/examples/item.json
+++ b/examples/item.json
@@ -47,7 +47,7 @@
       "cool_sensor_v1"
     ],
     "gsd": 0.66,
-    "proj:srid": "EPSG:32659",
+    "proj:code": "EPSG:32659",
     "proj:shape": [
       5558,
       9559

--- a/examples/item.json
+++ b/examples/item.json
@@ -47,8 +47,7 @@
       "cool_sensor_v1"
     ],
     "gsd": 0.66,
-    "proj:code": 32659,
-    "proj:authority": "epsg",
+    "proj:srid": "EPSG:32659",
     "proj:shape": [
       5558,
       9559

--- a/examples/item.json
+++ b/examples/item.json
@@ -47,7 +47,8 @@
       "cool_sensor_v1"
     ],
     "gsd": 0.66,
-    "proj:epsg": 32659,
+    "proj:code": 32659,
+    "proj:authority": "epsg",
     "proj:shape": [
       5558,
       9559

--- a/examples/item_custom_proj.json
+++ b/examples/item_custom_proj.json
@@ -1,0 +1,95 @@
+{
+  "stac_version": "1.0.0-rc.1",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+  ],
+  "type": "Feature",
+  "id": "20201211_223832_CS2",
+  "bbox": [
+    172.91173669923782,
+    1.3438851951615003,
+    172.95469614953714,
+    1.3690476620161975
+  ],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          172.91173669923782,
+          1.3438851951615003
+        ],
+        [
+          172.95469614953714,
+          1.3438851951615003
+        ],
+        [
+          172.95469614953714,
+          1.3690476620161975
+        ],
+        [
+          172.91173669923782,
+          1.3690476620161975
+        ],
+        [
+          172.91173669923782,
+          1.3438851951615003
+        ]
+      ]
+    ]
+  },
+  "properties": {
+    "datetime": "2020-12-11T22:38:32.125Z",
+    "created": "2020-12-12T01:48:13.725Z",
+    "updated": "2020-12-12T01:48:13.725Z",
+    "platform": "cool_sat2",
+    "instruments": [
+      "cool_sensor_v1"
+    ],
+    "gsd": 0.66,
+    "proj:autority": "iau_2015",
+    "proj:code": "49900",
+    "proj:shape": [
+      5558,
+      9559
+    ],
+    "proj:transform": [
+      0.5,
+      0,
+      712710,
+      0,
+      -0.5,
+      151406,
+      0,
+      0,
+      1
+    ]
+  },
+  "links": [],
+  "assets": {
+    "analytic": {
+      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_analytic.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "4-Band Analytic",
+      "roles": [
+        "data"
+      ]
+    },
+    "thumbnail": {
+      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",
+      "title": "Thumbnail",
+      "type": "image/png",
+      "roles": [
+        "thumbnail"
+      ]
+    },
+    "visual": {
+      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "3-Band Visual",
+      "roles": [
+        "visual"
+      ]
+    }
+  }
+}

--- a/examples/item_custom_proj.json
+++ b/examples/item_custom_proj.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "20201211_223832_CS2",
@@ -47,7 +47,7 @@
       "cool_sensor_v1"
     ],
     "gsd": 0.66,
-    "proj:srid": "IAU_2015:49900",
+    "proj:code": "IAU_2015:49900",
     "proj:shape": [
       5558,
       9559

--- a/examples/item_custom_proj.json
+++ b/examples/item_custom_proj.json
@@ -47,7 +47,7 @@
       "cool_sensor_v1"
     ],
     "gsd": 0.66,
-    "proj:code": "IAU_2015:49900",
+    "proj:srid": "IAU_2015:49900",
     "proj:shape": [
       5558,
       9559

--- a/examples/item_custom_proj.json
+++ b/examples/item_custom_proj.json
@@ -1,7 +1,7 @@
 {
-  "stac_version": "1.0.0-rc.1",
+  "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "20201211_223832_CS2",
@@ -65,7 +65,13 @@
       1
     ]
   },
-  "links": [],
+  "links": [
+    {
+      "href": "./collection.json",
+      "rel": "collection",
+      "type": "application/json"
+    }
+  ],
   "assets": {
     "analytic": {
       "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_analytic.tif",
@@ -73,14 +79,6 @@
       "title": "4-Band Analytic",
       "roles": [
         "data"
-      ]
-    },
-    "thumbnail": {
-      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",
-      "title": "Thumbnail",
-      "type": "image/png",
-      "roles": [
-        "thumbnail"
       ]
     },
     "visual": {
@@ -91,5 +89,6 @@
         "visual"
       ]
     }
-  }
+  },
+  "collection": "proj-example"
 }

--- a/examples/item_custom_proj.json
+++ b/examples/item_custom_proj.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
   ],
   "type": "Feature",
   "id": "20201211_223832_CS2",
@@ -47,8 +47,7 @@
       "cool_sensor_v1"
     ],
     "gsd": 0.66,
-    "proj:authority": "iau_2015",
-    "proj:code": "49900",
+    "proj:code": "IAU_2015:49900",
     "proj:shape": [
       5558,
       9559

--- a/examples/item_custom_proj.json
+++ b/examples/item_custom_proj.json
@@ -47,7 +47,7 @@
       "cool_sensor_v1"
     ],
     "gsd": 0.66,
-    "proj:autority": "iau_2015",
+    "proj:authority": "iau_2015",
     "proj:code": "49900",
     "proj:shape": [
       5558,

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -85,6 +85,14 @@
     "fields": {
       "type": "object",
       "properties": {
+        "proj:epsg":{
+          "deprecated": true,
+          "title":"EPSG code",
+          "type":[
+            "string",
+            "null"
+          ]
+        },
         "proj:code":{
           "title":"Projection code",
           "type":[

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -87,11 +87,7 @@
       "properties": {
         "proj:authority":{
           "title":"Authority granting the code",
-          "type":"string",
-          "enum": [
-            "epsg",
-            "iau_2015"
-          ]
+          "type":"string"
         },
         "proj:code":{
           "title":"Projection code",
@@ -100,7 +96,7 @@
         "proj:epsg":{
           "title":"EPSG code",
           "type":[
-            "string",
+            "integer",
             "null"
           ]
         },
@@ -191,6 +187,10 @@
       },
       "patternProperties": {
         "^(?!proj:)": {}
+      },
+      "dependentRequired":{
+        "proj:code" : ["proj:authority"],
+        "proj:authority": ["proj:code"]
       },
       "additionalProperties": false
     }

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -87,23 +87,20 @@
       "properties": {
         "proj:authority":{
           "title":"Authority granting the code",
-          "type":[
-            "string",
-            "null"
-          ],
-          "default":"epsg"
+          "type":"string",
+          "enum": [
+            "epsg",
+            "iau_2015"
+          ]
         },
         "proj:code":{
           "title":"Projection code",
-          "type":[
-            "integer",
-            "null"
-          ]
+          "type":"string"
         },
         "proj:epsg":{
           "title":"EPSG code",
           "type":[
-            "integer",
+            "string",
             "null"
           ]
         },

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -85,7 +85,7 @@
     "fields": {
       "type": "object",
       "properties": {
-        "proj:code":{
+        "proj:srid":{
           "title":"Projection code",
           "type":[
             "string",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -23,17 +23,7 @@
               "const": "Feature"
             },
             "properties": {
-              "allOf": [
-                {
-                  "$comment": "Require fields here for item properties.",
-                  "required": [
-                    "proj:code"
-                  ]
-                },
-                {
-                  "$ref": "#/definitions/fields"
-                }
-              ]
+              "$ref": "#/definitions/fields"
             },
             "assets": {
               "type": "object",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+  "$id": "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
   "title": "Projection Extension",
   "description": "STAC Projection Extension for STAC Items.",
   "$comment": "This schema succeeds if the proj: fields are not used at all, please keep this in mind.",
@@ -23,7 +23,17 @@
               "const": "Feature"
             },
             "properties": {
-              "$ref": "#/definitions/fields"
+              "allOf": [
+                {
+                  "$comment": "Require fields here for item properties.",
+                  "required": [
+                    "proj:code"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/fields"
+                }
+              ]
             },
             "assets": {
               "type": "object",
@@ -85,6 +95,21 @@
     "fields": {
       "type": "object",
       "properties": {
+        "proj:authority":{
+          "title":"Authority granting the code",
+          "type":[
+            "string",
+            "null"
+          ],
+          "default":"epsg"
+        },
+        "proj:code":{
+          "title":"Projection code",
+          "type":[
+            "integer",
+            "null"
+          ]
+        },
         "proj:epsg":{
           "title":"EPSG code",
           "type":[

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
+  "$id": "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
   "title": "Projection Extension",
   "description": "STAC Projection Extension for STAC Items.",
   "$comment": "This schema succeeds if the proj: fields are not used at all, please keep this in mind.",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -85,7 +85,7 @@
     "fields": {
       "type": "object",
       "properties": {
-        "proj:srid":{
+        "proj:code":{
           "title":"Projection code",
           "type":[
             "string",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -85,18 +85,10 @@
     "fields": {
       "type": "object",
       "properties": {
-        "proj:authority":{
-          "title":"Authority granting the code",
-          "type":"string"
-        },
         "proj:code":{
           "title":"Projection code",
-          "type":"string"
-        },
-        "proj:epsg":{
-          "title":"EPSG code",
           "type":[
-            "integer",
+            "string",
             "null"
           ]
         },
@@ -187,10 +179,6 @@
       },
       "patternProperties": {
         "^(?!proj:)": {}
-      },
-      "dependentRequired":{
-        "proj:code" : ["proj:authority"],
-        "proj:authority": ["proj:code"]
       },
       "additionalProperties": false
     }


### PR DESCRIPTION
Fixes #8.

This PR includes changes necessary to support IAU codes in the proj extension. To support non-EPSG codes, it is necessary to split the authority and the code into two separate fields. The PR adds `proj:authority` with a default of `epsg` and `proj:code`. The PR maintains the `proj:epsg` field for backwards compatibility.

I ticked the version of the extension to 2.0.0 since this should likely be a breaking change where `proj:epsg` is simply deprecated, but I am not 100% how the maintainers prefer to version the extension spec.

Happy to update, make changes, etc.

The follow on to this PR are PRs across the STAC ecosystem to update reading projections in the form `authority:code` instead of assuming EPSG.