### PR TITLE
Clarify that `proj:wkt2` or `proj:projjson` should be used for complex (non-EPSG) CRS #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added missing scope "Collection" to Readme. The scope was already supported in JSON Schemas.
+- Clarify that `proj:wkt2` or `proj:projjson` should be used for complex (non-EPSG) CRS
 
 ## [v1.0.0] - 2021-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated the PROJJSON schema to v0.5
+
 ### Deprecated
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This field should be set to `null` in the following cases:
 
 A Coordinate Reference System (CRS) is the data reference system (sometimes called a 'projection')
 used by the asset data. This value is a [PROJJSON](https://proj.org/specifications/projjson.html) object, 
-see the [JSON Schema](https://proj.org/schemas/v0.2/projjson.schema.json) for details.
+see the [JSON Schema](https://proj.org/schemas/v0.5/projjson.schema.json) for details.
 
 This field should be set to `null` in the following cases:
 - The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.

--- a/README.md
+++ b/README.md
@@ -44,25 +44,31 @@ The `proj` prefix is short for "projection", and is not a reference to the PROJ/
 A Coordinate Reference System (CRS) is the data reference system (sometimes called a
 'projection') used by the asset data, and can usually be referenced using an 
 [EPSG code](https://en.wikipedia.org/wiki/EPSG_Geodetic_Parameter_Dataset).
-If the asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control
-Points, `proj:epsg` should be set to null. It should also be set to null if a CRS exists, but for which
-there is no valid EPSG code. A great tool to help find EPSG codes is [epsg.io](http://epsg.io/).
+A great tool to help find EPSG codes is [epsg.io](http://epsg.io/).
+
+This field must be set to `null` in the following cases:
+- The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
+- A CRS exists, but there is no valid EPSG code for it. In this case, the CRS should be provided in `proj:wkt2` and/or `proj:projjson`.
+  Clients can prefer to take either, although there may be discrepancies in how each might be interpreted.
 
 #### proj:wkt2
 
-A Coordinate Reference System (CRS) is the data reference system (sometimes called a
-'projection') used by the asset data. This value is a [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string.
-If the data does not have a CRS, such as in the case of non-rectified imagery with Ground Control
-Points, proj:wkt2 should be set to null. It should also be set to null if a CRS exists, but for which
-a WKT2 string does not exist.
+A Coordinate Reference System (CRS) is the data reference system (sometimes called a 'projection')
+used by the asset data. This value is a [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string.
+
+This field should be set to `null` in the following cases:
+- The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
+- A CRS exists, but there is no valid WKT2 string for it.
 
 #### proj:projjson
 
-A Coordinate Reference System (CRS) is the data reference system (sometimes called a
-'projection') used by the asset data. This value is a [PROJJSON](https://proj.org/specifications/projjson.html) object.
-If the data does not have a CRS, such as in the case of non-rectified imagery with Ground Control
-Points, proj:projjson should be set to null. It should also be set to null if a CRS exists, but for which
-a PROJJSON string does not exist. The schema for this object can be found [here](https://proj.org/schemas/v0.2/projjson.schema.json).
+A Coordinate Reference System (CRS) is the data reference system (sometimes called a 'projection')
+used by the asset data. This value is a [PROJJSON](https://proj.org/specifications/projjson.html) object, 
+see the [JSON Schema](https://proj.org/schemas/v0.2/projjson.schema.json) for details.
+
+This field should be set to `null` in the following cases:
+- The asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points.
+- A CRS exists, but there is no valid WKT2 string for it.
 
 #### proj:geometry
 

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -113,7 +113,7 @@
           "title":"Coordinate Reference System in PROJJSON format",
           "oneOf": [
             {
-              "$ref": "https://proj.org/schemas/v0.4/projjson.schema.json"
+              "$ref": "https://proj.org/schemas/v0.5/projjson.schema.json"
             },
             {
               "type": "null"


### PR DESCRIPTION
Fixes #6 as proposed by @hobu.

Includes some restructuring of texts.

Also, updated the PROJJSON schema.